### PR TITLE
Muontools static

### DIFF
--- a/Mods/interface/MuonIDModRun1.h
+++ b/Mods/interface/MuonIDModRun1.h
@@ -127,7 +127,6 @@ namespace mithep
     ElectronCol        *fNonIsolatedElectrons;//!pointer to old electron collection
     TString             fPileupEnergyDensityName;
     const PileupEnergyDensityCol *fPileupEnergyDensity;
-    MuonTools          *fMuonTools;           // interface to tools for muon ID
     MuonIDMVA          *fMuonIDMVA;           // helper class for MuonMVA
     TString             fPVName;
 

--- a/Utils/interface/MuonIDMVA.h
+++ b/Utils/interface/MuonIDMVA.h
@@ -66,11 +66,11 @@ namespace mithep {
     Bool_t   IsInitialized() const { return fIsInitialized; }
     UInt_t   GetMVABin(double eta,double pt,
                        Bool_t isGlobal = kTRUE, Bool_t isTrackerMuon = kTRUE) const;
-    Double_t MVAValue(const Muon *mu, const Vertex *vertex, MuonTools *fMuonTools,
+    Double_t MVAValue(const Muon *mu, const Vertex *vertex,
                       const PFCandidateCol *PFCands, 
                       const PileupEnergyDensityCol *PileupEnergyDensity, 
                       Bool_t printDebug = kFALSE);
-    Double_t MVAValue(const Muon *mu, const Vertex *vertex, MuonTools *fMuonTools,
+    Double_t MVAValue(const Muon *mu, const Vertex *vertex,
                       const PFCandidateCol *PFCands, 
                       const PileupEnergyDensityCol *PileupEnergyDensity, 
                       MuonTools::EMuonEffectiveAreaTarget EffectiveAreaTarget,

--- a/Utils/interface/MuonTools.h
+++ b/Utils/interface/MuonTools.h
@@ -29,10 +29,6 @@
 namespace mithep {
   class MuonTools {
     public:
-      MuonTools(const char *mutemp="$MIT_DATA/MuonCaloTemplate.root", 
-                const char *pitemp="$MIT_DATA/PionCaloTemplate.root");
-      virtual ~MuonTools();
-
       enum EMuIdType {
         kIdUndef = 0,       //not defined
         kWMuId,             //"WMuId"
@@ -152,11 +148,10 @@ namespace mithep {
         kMuEAData2012
       };
 
-      Bool_t          Init(const char *mutemp, const char *pitemp);
-      Bool_t          IsGood(const mithep::Muon *iMuon, ESelType iSel) const;
-      Double_t        GetCaloCompatibility(const mithep::Muon *iMuon,
-                                         Bool_t iEMSpecial, Bool_t iCorrectedHCAL) const; 
-      Double_t        GetSegmentCompatibility(const mithep::Muon *iMuon)             const;
+      static Bool_t   IsGood(const mithep::Muon *iMuon, ESelType iSel);
+      static Double_t GetCaloCompatibility(const mithep::Muon *iMuon,
+                                           Bool_t iEMSpecial, Bool_t iCorrectedHCAL);
+      static Double_t GetSegmentCompatibility(const mithep::Muon *iMuon);
       static Bool_t   PassD0Cut(const Muon *mu, const VertexCol *vertices, EMuIdType, Int_t iVertex = 0);
       static Bool_t   PassD0Cut(const Muon *mu, const BeamSpotCol *beamspots, EMuIdType);
       static Bool_t   PassD0Cut(const Muon *mu, Double_t d0, EMuIdType);
@@ -178,40 +173,45 @@ namespace mithep {
       static Bool_t     PassClass(Muon const*, EMuClassType classType);
       static void       MuonPtEta(Muon const*, EMuClassType classType, Double_t& pt, Double_t& absEta);
 
+      static Bool_t   LoadCaloCompatibilityTemplates(const char *mutemp, const char *pitemp, Bool_t force = kFALSE);
+      static void     DeleteCaloCompatibilityTemplates();
+
     protected:
-      void        DeleteHistos();
-      Bool_t      Overflow(const TH2D *iHist, Double_t lVal0, Double_t lVal1)    const; 
-      Double_t    SigWeight(Double_t iVal0, Double_t iVal1)                      const; 
+      MuonTools() {}
+      virtual ~MuonTools() {}
+
+      static Bool_t   Overflow(const TH2D *iHist, Double_t lVal0, Double_t lVal1);
+      static Double_t SigWeight(Double_t iVal0, Double_t iVal1);
    
     private:
-      Bool_t      fIsInit;              //!=true if histograms are loaded
-      TH2D       *fmuon_em_etaEmi;      //!Neg Endcap EM       Calo Deposit Template for Muons
-      TH2D       *fmuon_had_etaEmi;     //!Neg Endcap Hadronic Calo Deposit Template for Muons
-      TH2D       *fmuon_had_etaTmi;     //!Neg Transition Hadronic Calo Deposit Template for Muons
-      TH2D       *fmuon_em_etaB;        //!Barrel EM       Calo Deposit Template for Muons
-      TH2D       *fmuon_had_etaB;       //!Barrel Hadronic Calo Deposit Template for Muons
-      TH2D       *fmuon_ho_etaB;        //!Barrel HO       Calo Deposit Template for Muons
-      TH2D       *fmuon_had_etaTpl;     //!Plus Transition Hadronic Calo Deposit Template for Muons
-      TH2D       *fmuon_em_etaEpl;      //!Plus Endcap EM       Calo Deposit Template for Muons
-      TH2D       *fmuon_had_etaEpl;     //!Plus Endcap Hadronic Calo Deposit Template for Muons
-      TH2D       *fpion_em_etaEmi;      //!Neg  Endcap EM       Calo Deposit Template for Pions
-      TH2D       *fpion_had_etaEmi;     //!Neg  Endcap Hadronic Calo Deposit Template for Pions
-      TH2D       *fpion_had_etaTmi;     //!Neg Transition Hadronic Calo Deposit Template for Pions
-      TH2D       *fpion_em_etaB;        //!Barrel EM       Calo Deposit Template for Pions
-      TH2D       *fpion_had_etaB;       //!Barrel Hadronic Calo Deposit Template for Pions
-      TH2D       *fpion_ho_etaB;        //!Barrel HO       Calo Deposit Template for Pions
-      TH2D       *fpion_had_etaTpl;     //!Plus Transition Hadronic Calo Deposit Template for Pions
-      TH2D       *fpion_em_etaEpl;      //!Plus Endcap EM       Calo Deposit Template for Pions
-      TH2D       *fpion_had_etaEpl;     //!Plus Endcap Hadronic Calo Deposit Template for Pions
+      static Bool_t  fCaloCompatTemplatesSet;
+      static TH2D   *fmuon_em_etaEmi;      //!Neg Endcap EM       Calo Deposit Template for Muons
+      static TH2D   *fmuon_had_etaEmi;     //!Neg Endcap Hadronic Calo Deposit Template for Muons
+      static TH2D   *fmuon_had_etaTmi;     //!Neg Transition Hadronic Calo Deposit Template for Muons
+      static TH2D   *fmuon_em_etaB;        //!Barrel EM       Calo Deposit Template for Muons
+      static TH2D   *fmuon_had_etaB;       //!Barrel Hadronic Calo Deposit Template for Muons
+      static TH2D   *fmuon_ho_etaB;        //!Barrel HO       Calo Deposit Template for Muons
+      static TH2D   *fmuon_had_etaTpl;     //!Plus Transition Hadronic Calo Deposit Template for Muons
+      static TH2D   *fmuon_em_etaEpl;      //!Plus Endcap EM       Calo Deposit Template for Muons
+      static TH2D   *fmuon_had_etaEpl;     //!Plus Endcap Hadronic Calo Deposit Template for Muons
+      static TH2D   *fpion_em_etaEmi;      //!Neg  Endcap EM       Calo Deposit Template for Pions
+      static TH2D   *fpion_had_etaEmi;     //!Neg  Endcap Hadronic Calo Deposit Template for Pions
+      static TH2D   *fpion_had_etaTmi;     //!Neg Transition Hadronic Calo Deposit Template for Pions
+      static TH2D   *fpion_em_etaB;        //!Barrel EM       Calo Deposit Template for Pions
+      static TH2D   *fpion_had_etaB;       //!Barrel Hadronic Calo Deposit Template for Pions
+      static TH2D   *fpion_ho_etaB;        //!Barrel HO       Calo Deposit Template for Pions
+      static TH2D   *fpion_had_etaTpl;     //!Plus Transition Hadronic Calo Deposit Template for Pions
+      static TH2D   *fpion_em_etaEpl;      //!Plus Endcap EM       Calo Deposit Template for Pions
+      static TH2D   *fpion_had_etaEpl;     //!Plus Endcap Hadronic Calo Deposit Template for Pions
 
-      TH2D       *LoadHisto(const char *fname, TFile *file)                      const;
+      static TH2D   *LoadHisto(const char *fname, TFile *file);
 
     ClassDef(MuonTools, 1) // Muon tools
   };
 }
 
 //--------------------------------------------------------------------------------------------------
-inline Double_t mithep::MuonTools::SigWeight(Double_t iVal0, Double_t iVal1) const
+inline Double_t mithep::MuonTools::SigWeight(Double_t iVal0, Double_t iVal1)
 {
   // Returns weighted uncertainty given segment matching uncertainty (iVal0) and
   // segment matching pull (iVal1).
@@ -227,7 +227,7 @@ inline Double_t mithep::MuonTools::SigWeight(Double_t iVal0, Double_t iVal1) con
   return 1./TMath::Power(lVal,0.25);
 }
 //--------------------------------------------------------------------------------------------------
-inline Bool_t mithep::MuonTools::Overflow(const TH2D *iHist, Double_t lVal0, Double_t lVal1) const
+inline Bool_t mithep::MuonTools::Overflow(const TH2D *iHist, Double_t lVal0, Double_t lVal1)
 {
   // Check if values are in overflow bins of given histogram.
 

--- a/Utils/src/MuonIDMVA.cc
+++ b/Utils/src/MuonIDMVA.cc
@@ -665,7 +665,7 @@ Double_t MuonIDMVA::MVAValue_ID( Double_t MuPt,
 
 
 //--------------------------------------------------------------------------------------------------
-Double_t MuonIDMVA::MVAValue(const Muon *mu, const Vertex *vertex, MuonTools *fMuonTools,
+Double_t MuonIDMVA::MVAValue(const Muon *mu, const Vertex *vertex,
                              const PFCandidateCol *PFCands, 
                              const PileupEnergyDensityCol *PileupEnergyDensity, 
                              Bool_t printDebug) {
@@ -706,8 +706,8 @@ Double_t MuonIDMVA::MVAValue(const Muon *mu, const Vertex *vertex, MuonTools *fM
   fMVAVar_MuIP3d                 = mu->Ip3dPV();
   fMVAVar_MuIP3dSig              = mu->Ip3dPVSignificance();
   fMVAVar_MuTrkKink              = mu->TrkKink();
-  fMVAVar_MuSegmentCompatibility = fMuonTools->GetSegmentCompatibility(mu);
-  fMVAVar_MuCaloCompatibility    = fMuonTools->GetCaloCompatibility(mu, kTRUE, kTRUE);
+  fMVAVar_MuSegmentCompatibility = MuonTools::GetSegmentCompatibility(mu);
+  fMVAVar_MuCaloCompatibility    = MuonTools::GetCaloCompatibility(mu, kTRUE, kTRUE);
   fMVAVar_MuHadEnergyOverPt      = (mu->HadEnergy() - Rho*MuonTools::MuonEffectiveArea(MuonTools::kMuHadEnergy,muTrk->Eta()))/muTrk->Pt();
   fMVAVar_MuHoEnergyOverPt       = (mu->HoEnergy() - Rho*MuonTools::MuonEffectiveArea(MuonTools::kMuHoEnergy,muTrk->Eta()))/muTrk->Pt();
   fMVAVar_MuEmEnergyOverPt       = (mu->EmEnergy() - Rho*MuonTools::MuonEffectiveArea(MuonTools::kMuEmEnergy,muTrk->Eta()))/muTrk->Pt();
@@ -773,7 +773,7 @@ Double_t MuonIDMVA::MVAValue(const Muon *mu, const Vertex *vertex, MuonTools *fM
 
 
 //--------------------------------------------------------------------------------------------------
-Double_t MuonIDMVA::MVAValue(const Muon *mu, const Vertex *vertex, MuonTools *fMuonTools,
+Double_t MuonIDMVA::MVAValue(const Muon *mu, const Vertex *vertex,
                              const PFCandidateCol *PFCands, 
                              const PileupEnergyDensityCol *PileupEnergyDensity, 
                              MuonTools::EMuonEffectiveAreaTarget EffectiveAreaTarget,
@@ -819,8 +819,8 @@ Double_t MuonIDMVA::MVAValue(const Muon *mu, const Vertex *vertex, MuonTools *fM
   fMVAVar_MuIP3d                 = mu->Ip3dPV();
   fMVAVar_MuIP3dSig              = mu->Ip3dPVSignificance();
   fMVAVar_MuTrkKink              = mu->TrkKink();
-  fMVAVar_MuSegmentCompatibility = fMuonTools->GetSegmentCompatibility(mu);
-  fMVAVar_MuCaloCompatibility    = fMuonTools->GetCaloCompatibility(mu, kTRUE, kTRUE);
+  fMVAVar_MuSegmentCompatibility = MuonTools::GetSegmentCompatibility(mu);
+  fMVAVar_MuCaloCompatibility    = MuonTools::GetCaloCompatibility(mu, kTRUE, kTRUE);
   fMVAVar_MuHadEnergy            = mu->HadEnergy() ;
   fMVAVar_MuEmEnergy             = mu->EmEnergy();
   fMVAVar_MuHadS9Energy          = mu->HadS9Energy();

--- a/Utils/src/MuonTools.cc
+++ b/Utils/src/MuonTools.cc
@@ -688,23 +688,26 @@ mithep::MuonTools::PassId(const Muon *mu, EMuIdType idType)
   // 2015 POG Medium ID for Run-2 as of 2015-07-24
   // Loose muon with a few additional requirements
   case kMedium:
-    return mu->BestTrk() != 0 &&
-      mu->IsPFMuon() == kTRUE &&
-      (
-        mu->Quality().Quality(MuonQuality::AllGlobalMuons) ||
-        mu->Quality().Quality(MuonQuality::AllTrackerMuons)
-      ) && 
-      mu->ValidFraction() > 0.8 &&
-      (
+    {
+      double segComp = GetSegmentCompatibility(mu);
+      return mu->BestTrk() != 0 &&
+        mu->IsPFMuon() == kTRUE &&
         (
+         mu->Quality().Quality(MuonQuality::AllGlobalMuons) ||
+         mu->Quality().Quality(MuonQuality::AllTrackerMuons)
+        ) && 
+        mu->ValidFraction() > 0.8 &&
+        (
+         (
           mu->Quality().Quality(MuonQuality::AllGlobalMuons) &&
           normChi2 < 3.0 && 
           mu->Chi2LocalPosition() < 12.0 &&
           mu->TrkKink() < 20.0 &&
-          GetSegmentCompatibility(mu) > .303
-        ) ||
-        GetSegmentCompatibility(mu) > .451
-      );
+          segComp > .303
+         ) ||
+         segComp > .451
+        );
+    }
 
   // 2015 POG Tight ID for Run-2 as of 2015-07-24
   // Global muon with additional muon-quality requirements.

--- a/Utils/src/MuonTools.cc
+++ b/Utils/src/MuonTools.cc
@@ -7,91 +7,73 @@ ClassImp(mithep::MuonTools)
 
 using namespace mithep;
 
-//--------------------------------------------------------------------------------------------------
-MuonTools::MuonTools(const char *mutemp, const char *pitemp) :
-  fIsInit(kFALSE),
-  fmuon_em_etaEmi(0),
-  fmuon_had_etaEmi(0),
-  fmuon_had_etaTmi(0),
-  fmuon_em_etaB(0),
-  fmuon_had_etaB(0),
-  fmuon_ho_etaB(0),
-  fmuon_had_etaTpl(0),
-  fmuon_em_etaEpl(0),
-  fmuon_had_etaEpl(0),
-  fpion_em_etaEmi(0),
-  fpion_had_etaEmi(0),
-  fpion_had_etaTmi(0),
-  fpion_em_etaB(0),
-  fpion_had_etaB(0),
-  fpion_ho_etaB(0),
-  fpion_had_etaTpl(0),
-  fpion_em_etaEpl(0),
-  fpion_had_etaEpl(0)
-{
-  // Constructor.
-
-  if (mutemp && pitemp)
-    Init(mutemp, pitemp);
-}
+Bool_t MuonTools::fCaloCompatTemplatesSet{kFALSE};
+TH2D* MuonTools::fmuon_em_etaEmi{0};
+TH2D* MuonTools::fmuon_had_etaEmi{0};
+TH2D* MuonTools::fmuon_had_etaTmi{0};
+TH2D* MuonTools::fmuon_em_etaB{0};
+TH2D* MuonTools::fmuon_had_etaB{0};
+TH2D* MuonTools::fmuon_ho_etaB{0};
+TH2D* MuonTools::fmuon_had_etaTpl{0};
+TH2D* MuonTools::fmuon_em_etaEpl{0};
+TH2D* MuonTools::fmuon_had_etaEpl{0};
+TH2D* MuonTools::fpion_em_etaEmi{0};
+TH2D* MuonTools::fpion_had_etaEmi{0};
+TH2D* MuonTools::fpion_had_etaTmi{0};
+TH2D* MuonTools::fpion_em_etaB{0};
+TH2D* MuonTools::fpion_had_etaB{0};
+TH2D* MuonTools::fpion_ho_etaB{0};
+TH2D* MuonTools::fpion_had_etaTpl{0};
+TH2D* MuonTools::fpion_em_etaEpl{0};
+TH2D* MuonTools::fpion_had_etaEpl{0};
 
 //--------------------------------------------------------------------------------------------------
-MuonTools::~MuonTools() 
-{
-  // Destructor.
-
-  DeleteHistos();
-}
-
-//--------------------------------------------------------------------------------------------------
-void MuonTools::DeleteHistos()
+void MuonTools::DeleteCaloCompatibilityTemplates()
 {
   // Delete histograms.
+  delete fpion_em_etaEmi; 
+  delete fpion_had_etaEmi;
+  delete fpion_had_etaTmi;
+  delete fpion_em_etaB;
+  delete fpion_had_etaB;
+  delete fpion_ho_etaB;
+  delete fpion_had_etaTpl;
+  delete fpion_em_etaEpl;
+  delete fpion_had_etaEpl;
+  delete fmuon_em_etaEmi;
+  delete fmuon_had_etaEmi;
+  delete fmuon_had_etaTmi;
+  delete fmuon_em_etaB;
+  delete fmuon_had_etaB;
+  delete fmuon_ho_etaB;
+  delete fmuon_had_etaTpl;
+  delete fmuon_em_etaEpl;
+  delete fmuon_had_etaEpl;
+  fpion_em_etaEmi  = 0;
+  fpion_had_etaEmi = 0;
+  fpion_had_etaTmi = 0;
+  fpion_em_etaB    = 0;
+  fpion_had_etaB   = 0;
+  fpion_ho_etaB    = 0;
+  fpion_had_etaTpl = 0;
+  fpion_em_etaEpl  = 0;
+  fpion_had_etaEpl = 0;
+  fmuon_em_etaEmi  = 0;
+  fmuon_had_etaEmi = 0;
+  fmuon_had_etaTmi = 0;
+  fmuon_em_etaB    = 0;
+  fmuon_had_etaB   = 0;
+  fmuon_ho_etaB    = 0;
+  fmuon_had_etaTpl = 0;
+  fmuon_em_etaEpl  = 0;
+  fmuon_had_etaEpl = 0;
 
-  if (fIsInit) {
-    delete fpion_em_etaEmi; 
-    delete fpion_had_etaEmi;
-    delete fpion_had_etaTmi;
-    delete fpion_em_etaB;
-    delete fpion_had_etaB;
-    delete fpion_ho_etaB;
-    delete fpion_had_etaTpl;
-    delete fpion_em_etaEpl;
-    delete fpion_had_etaEpl;
-    delete fmuon_em_etaEmi;
-    delete fmuon_had_etaEmi;
-    delete fmuon_had_etaTmi;
-    delete fmuon_em_etaB;
-    delete fmuon_had_etaB;
-    delete fmuon_ho_etaB;
-    delete fmuon_had_etaTpl;
-    delete fmuon_em_etaEpl;
-    delete fmuon_had_etaEpl;
-    fpion_em_etaEmi  = 0;
-    fpion_had_etaEmi = 0;
-    fpion_had_etaTmi = 0;
-    fpion_em_etaB    = 0;
-    fpion_had_etaB   = 0;
-    fpion_ho_etaB    = 0;
-    fpion_had_etaTpl = 0;
-    fpion_em_etaEpl  = 0;
-    fpion_had_etaEpl = 0;
-    fmuon_em_etaEmi  = 0;
-    fmuon_had_etaEmi = 0;
-    fmuon_had_etaTmi = 0;
-    fmuon_em_etaB    = 0;
-    fmuon_had_etaB   = 0;
-    fmuon_ho_etaB    = 0;
-    fmuon_had_etaTpl = 0;
-    fmuon_em_etaEpl  = 0;
-    fmuon_had_etaEpl = 0;
-    fIsInit = kFALSE;
-  }
+  fCaloCompatTemplatesSet = kFALSE;
 }
 
 //--------------------------------------------------------------------------------------------------
 Double_t MuonTools::GetCaloCompatibility(const Muon *iMuon,
-                                         Bool_t iEMSpecial, Bool_t iCorrectedHCAL) const
+                                         Bool_t iEMSpecial, Bool_t iCorrectedHCAL)
 {
   // Get calo compatibility value for given muon based on calorimeter templates.
   // If iEMSpecial is true, then a use different arrangement of ECAL for compatibility.
@@ -167,6 +149,11 @@ Double_t MuonTools::GetCaloCompatibility(const Muon *iMuon,
     lTPionHo  = fpion_ho_etaB;
     lTMuonHo  = fmuon_ho_etaB;
   }
+
+  if (!lTPionEm || !lTPionHad || !lTPionHo || !lTMuonEm || !lTMuonHad || !lTMuonHo) {
+    Error("GetCaloCompatibility", "Template histograms not available");
+    throw std::runtime_error("muon calo compatibility");
+  }
   
   Double_t lPBX = 1.;     
   Double_t lPSX = 1.; 
@@ -212,13 +199,14 @@ Double_t MuonTools::GetCaloCompatibility(const Muon *iMuon,
 }
 
 //--------------------------------------------------------------------------------------------------
-Bool_t MuonTools::Init(const char *mutemp, const char *pitemp)
+Bool_t MuonTools::LoadCaloCompatibilityTemplates(const char *mutemp, const char *pitemp, Bool_t force/* = kFALSE*/)
 {
   // Read histograms from given files.
 
-  if (fIsInit) {
-    DeleteHistos();
-  }
+  if (fCaloCompatTemplatesSet && !force)
+    return kTRUE;
+
+  DeleteCaloCompatibilityTemplates();
 
   TDirectory::TContext context(0);
 
@@ -257,12 +245,13 @@ Bool_t MuonTools::Init(const char *mutemp, const char *pitemp)
   pion_templates->Close();
   delete pion_templates;
 
-  fIsInit = kTRUE;
+  fCaloCompatTemplatesSet = kTRUE;
+
   return kTRUE;
 }
 
 //--------------------------------------------------------------------------------------------------
-Bool_t MuonTools::IsGood(const mithep::Muon *iMuon, ESelType iSel) const
+Bool_t MuonTools::IsGood(const mithep::Muon *iMuon, ESelType iSel)
 {
   // Return true if given muon qualifies given selection criterium.
 
@@ -315,7 +304,7 @@ Bool_t MuonTools::IsGood(const mithep::Muon *iMuon, ESelType iSel) const
 }
 
 //--------------------------------------------------------------------------------------------------
-Double_t MuonTools::GetSegmentCompatibility(const mithep::Muon *iMuon) const
+Double_t MuonTools::GetSegmentCompatibility(const mithep::Muon *iMuon)
 {
   // Get segment compatability for given muon based on likelihood of well defined 
   // track through chambers.
@@ -662,7 +651,6 @@ mithep::MuonTools::PassPFIso(Muon const* mu, EMuIsoType type, PFCandidateCol con
 Bool_t
 mithep::MuonTools::PassId(const Muon *mu, EMuIdType idType)
 {
-  MuonTools muAxe; // dummy instantiation to use static members
   Double_t normChi2 = 0.0;
   if (mu->HasGlobalTrk())
     normChi2 = mu->GlobalTrk()->Chi2() / mu->GlobalTrk()->Ndof();
@@ -713,9 +701,9 @@ mithep::MuonTools::PassId(const Muon *mu, EMuIdType idType)
           normChi2 < 3.0 && 
           mu->Chi2LocalPosition() < 12.0 &&
           mu->TrkKink() < 20.0 &&
-          muAxe.GetSegmentCompatibility(mu) > .303
+          GetSegmentCompatibility(mu) > .303
         ) ||
-        muAxe.GetSegmentCompatibility(mu) > .451
+        GetSegmentCompatibility(mu) > .451
       );
 
   // 2015 POG Tight ID for Run-2 as of 2015-07-24
@@ -728,8 +716,6 @@ mithep::MuonTools::PassId(const Muon *mu, EMuIdType idType)
       normChi2 < 10.0 && 
       mu->NValidHits() > 0 && // number of valid muon hits on the muon chambers in the global track:
       mu->NMatches() > 2 &&
-      mu->BestTrk()->Dxy() < 0.2 &&
-      mu->BestTrk()->Dsz() < 0.5 &&
       mu->BestTrk()->NPixelHits() > 0 &&
       mu->NTrkLayersHit() > 5;
 
@@ -786,7 +772,7 @@ mithep::MuonTools::PassId(const Muon *mu, EMuIdType idType)
 }
 
 //--------------------------------------------------------------------------------------------------
-TH2D *MuonTools::LoadHisto(const char *name, TFile *file) const
+TH2D *MuonTools::LoadHisto(const char *name, TFile *file)
 {
   // Load histogram with given name from given file and return it.
 


### PR DESCRIPTION
All MuonTools members are now static. It was a bad idea to mix static and non-static usage in a single class.
A side note: turns out GetSegmentCompatibility did not have to be non-static even in the previous implementation. It was only GetCaloCompatibility where input data was needed.

Also dropped Dxy and Dz from Tight muon Id, since these conditions are applied independently by passDzCut and passD0Cut functions (which are called by MuonIdMod).